### PR TITLE
Fix incorrect bash shebangs

### DIFF
--- a/build_image.sh
+++ b/build_image.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 AMIDES_TAG="amides:base"
 UID=$(id -u)

--- a/run_experiments.sh
+++ b/run_experiments.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 AMIDES_IMAGE="amides:base"
 AMIDES_EXPERIMENTS_CONTAINER="amides-experiments"

--- a/start_env.sh
+++ b/start_env.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 AMIDES_IMAGE="amides:base"
 AMIDES_ENV_CONTAINER="amides-env"


### PR DESCRIPTION
While `#!/usr/bin/bash` seems to work under Ubuntu, it does not on macOS. `#!/usr/bin/env bash` would be an alternative, however, I prefer `#!/bin/bash`, which is also consistent with the other scripts in this repo. See [here](https://stackoverflow.com/a/52860837) for a discussion on the topic.